### PR TITLE
Eip 4844

### DIFF
--- a/zkevm-circuits/src/blobkzg_circuit/.gitignore
+++ b/zkevm-circuits/src/blobkzg_circuit/.gitignore
@@ -1,3 +1,2 @@
 
 target/
-Cargo.lock

--- a/zkevm-circuits/src/blobkzg_circuit/Cargo.toml
+++ b/zkevm-circuits/src/blobkzg_circuit/Cargo.toml
@@ -7,10 +7,12 @@ authors = ["mabbamOG <mariobarbara@protonmail.ch>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2_proofs = { git = "https://github.com/mabbamOG/halo2.git" } 
-halo2wrong_integer = {package = "integer", git = "https://github.com/mabbamOG/halo2wrong"} 
-halo2wrong_maingate = {package = "maingate", git = "https://github.com/mabbamOG/halo2wrong"}
+halo2_proofs = { git = "https://github.com/mabbamOG/halo2.git" }  # patched version of halo2 that supports the new curve traits (will be merged eventually)
+halo2wrong_integer = {package = "integer", git = "https://github.com/mabbamOG/halo2wrong"} # patched version of halo2wrong that supports the new curve traits (will be merged eventually)
+halo2wrong_maingate = {package = "maingate", git = "https://github.com/mabbamOG/halo2wrong"} # patched version of halo2wrong that supports the new curve traits (will be merged eventually)
 
 [dev-dependencies]
 rand_core = "0.6.4"
 rand = "0.8.5"
+
+[workspace] # empty workspace as a temp fix for the project being separate from zkevm-circuits


### PR DESCRIPTION
Reopening PR because of mistake, previous PR: https://github.com/taikoxyz/zkevm-circuits/pull/106

### Description

This PR adds the circuit required to integrate Taiko with EIP 4844. Basically it takes data stored in the circuit and uses it for function evaluation. This is then compared with the blob opening checked in the smart contract with EIP 4844. Make sure the data fed into this circuit is checked to be the same as all the other claims of the proof.

### Issue Link

https://github.com/taikoxyz/zkevm-circuits/issues/37

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Contents

Contain the new circuit as well as dependencies which support the latest traits along with the latest halo2curves (hence the breaking change...but the circuit has not been integrated into the rest of the zkEVM so everything compiles for now)

### Rationale

Required for the L2 to make use of EIP 4844 Blobs, greatly improving costs for publishing new proofs

### How Has This Been Tested?

unit tests

<hr>
